### PR TITLE
Patch/#32 - Switch `/group` placement

### DIFF
--- a/routes/group_route.go
+++ b/routes/group_route.go
@@ -11,5 +11,5 @@ var (
 )
 
 func groupRoute(g *gin.RouterGroup) {
-	g.POST("/group", middleware.VerifyAuthenticated(), groupController.Create)
+	g.POST("/", middleware.VerifyAuthenticated(), groupController.Create)
 }

--- a/routes/server.go
+++ b/routes/server.go
@@ -17,7 +17,7 @@ func SetupRouter() {
 	})
 
 	authRoute(router.Group("/auth"))
-	groupRoute(router.Group("/"))
+	groupRoute(router.Group("/group"))
 
 	router.Run()
 }


### PR DESCRIPTION
<!--- BEFORE SUBMITTING YOUR PR, CHECK THAT: --->
<!--- 1) Your PR has a descriptive name --->
<!--- 2) This PR template is filled out --->
<!--- 3) You wrote tests for your change --->

# Contributors
<!--- Your github handles here, ex: @brandonLi8 --->
@brandonLi8 

# Relevant issue
<!--- Put the issue number here. --->
Closes #32 

# Summary of change
<!--- Describe the change that this pull request makes. --->
<!--- Add screenshots here if relevant --->
Currently we have:

```go
in sever.go:
groupRoute(router.Group("/"))

in group_route.go:
g.POST("/group")
```

Switched the order so it becomes:

```go
in sever.go:
groupRoute(router.Group("/group"))

in group_route.go:
g.POST("/")
```
# Testing/Verification
<!--- How did you test your change? Reference any files you changed/added here. --->
n/a