### PR TITLE
Feat/#26: Create Challenge route

### DIFF
--- a/controllers/challenge_controller.go
+++ b/controllers/challenge_controller.go
@@ -29,7 +29,7 @@ func (ctrl *challengeController) Create(context *gin.Context) {
 		Latitude    float64 `json:"latitude"`
 		Longitude   float64 `json:"longitude"`
 		Address     string  `json:"address"`
-		TaskName    string  `json:"taskName" binding:"required"`
+		Name        string  `json:"name" binding:"required"`
 		Description string  `json:"description" binding:"required"`
 		Points      int     `json:"points" binding:"required,min=0"`
 	}
@@ -41,7 +41,7 @@ func (ctrl *challengeController) Create(context *gin.Context) {
 	location := models.Location{}
 
 	challenge := models.Challenge{
-		TaskName:    body.TaskName,
+		Name:        body.Name,
 		Description: body.Description,
 		Points:      body.Points,
 	}
@@ -75,7 +75,7 @@ func (ctrl *challengeController) Create(context *gin.Context) {
 
 	challengeCollection := mgm.Coll(&challenge)
 
-	query := bson.M{"taskName": challenge.TaskName}
+	query := bson.M{"name": challenge.Name}
 
 	// If location info is included in our challenge, validate duplicates based on this field as well.
 	if challenge.Location != nil {

--- a/controllers/challenge_controller.go
+++ b/controllers/challenge_controller.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/drift-org/backend/models"
+	"github.com/gin-gonic/gin"
+	"github.com/kamva/mgm/v3"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type ChallengeController interface {
+	Create(context *gin.Context)
+}
+
+type challengeController struct{}
+
+func NewChallengeController() ChallengeController {
+	return &challengeController{}
+}
+
+// TODO: Idea for future, if we want to let companies/orgs create challenges (Business Model #3).
+// Default method of adding challenges on frontend is to add by placing a marker on a map
+// (allowing us to grab Lat/Long coordinates). We can also offer a (premium) option for users to
+// provide just the address, and convert to Lat/Long -- thus allowing batch creation of challenges.
+func (ctrl *challengeController) Create(context *gin.Context) {
+	type ICreate struct {
+		Latitude    float64 `json:"latitude"`
+		Longitude   float64 `json:"longitude"`
+		Address     string  `json:"address"`
+		TaskName    string  `json:"taskName" binding:"required"`
+		Description string  `json:"description" binding:"required"`
+		Points      int     `json:"points" binding:"required,min=1"`
+	}
+	var body ICreate
+	if err := context.ShouldBindJSON(&body); err != nil {
+		context.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	location := models.Location{}
+
+	challenge := models.Challenge{
+		TaskName:    body.TaskName,
+		Description: body.Description,
+		Points:      body.Points,
+	}
+
+	// If lat/long/address information is provided, include it in our Challenge model.
+	if body.Latitude != 0 && body.Longitude != 0 && body.Address != "" {
+		location.Type = "Point"
+		location.Coordinates = []float64{body.Longitude, body.Latitude}
+		challenge.Location = location
+		challenge.Address = body.Address
+	}
+	challengeCollection := mgm.Coll(&challenge)
+	// Check if a challenge with the same address and task exist. If so, throw an error.
+	if err := challengeCollection.First(bson.M{"taskName": challenge.TaskName, "address": challenge.Address}, &challenge); err == nil {
+		context.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Challenge with same address and task name already exists."})
+		return
+	}
+
+	if err := challengeCollection.Create(&challenge); err != nil {
+		fmt.Println(err.Error())
+		context.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	context.JSON(http.StatusOK, gin.H{"message": "Success", "challenge": challenge})
+}

--- a/controllers/challenge_controller.go
+++ b/controllers/challenge_controller.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/drift-org/backend/models"
@@ -48,9 +47,8 @@ func (ctrl *challengeController) Create(context *gin.Context) {
 
 	// If lat/long/address information is provided, include it in our Challenge model.
 	if body.Latitude != 0 && body.Longitude != 0 && body.Address != "" {
-		location.Type = "Point"
 		location.Coordinates = []float64{body.Longitude, body.Latitude}
-		challenge.Location = location
+		challenge.Location = &location
 		challenge.Address = body.Address
 	}
 	challengeCollection := mgm.Coll(&challenge)
@@ -61,7 +59,6 @@ func (ctrl *challengeController) Create(context *gin.Context) {
 	}
 
 	if err := challengeCollection.Create(&challenge); err != nil {
-		fmt.Println(err.Error())
 		context.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/controllers/challenge_controller_test.go
+++ b/controllers/challenge_controller_test.go
@@ -21,15 +21,15 @@ var _ = Describe("ChallengeController", func() {
 	)
 
 	Describe("Register", func() {
-		It("Basic", helpers.TestWithMongo("ChallengeController-Create", func() {
+		It("Basic & Unique Task Name/Location", helpers.TestWithMongo("ChallengeController-Create-Unique", func() {
 
 			// Create a sample request for a challenge to be created.
 			context := helpers.CreateTestContext("", `{
-				"latitude": 10.01,
-				"longitude": 10.01,
+				"latitude": 34.0701449,
+				"longitude": -118.4422936,
 				"address": "1234 Main Street",
 				"taskName": "Task 1",
-				"description": "Description 1",
+				"description": "Description",
 				"points": 10
 			}`)
 
@@ -42,42 +42,169 @@ var _ = Describe("ChallengeController", func() {
 			_ = mgm.Coll(challenge).First(bson.M{}, challenge)
 			Expect(challenge).NotTo(BeNil())
 
-			// Attempt creating a challenge with the same address & taskName.
-			duplicateContext1 := helpers.CreateTestContext("", `{
-				"latitude": 10.01,
-				"longitude": 10.01,
-				"address": "1234 Main Street",
-				"taskName": "Task 1",
-				"description": "Description 2",
-				"points": 20
-			}`)
-			challengeController.Create(duplicateContext1)
-			Expect(duplicateContext1.Writer.Status()).To(Equal(http.StatusBadRequest))
-
-			// Attempt creating a user with just the same address.
-			duplicateContext2 := helpers.CreateTestContext("", `{
-				"latitude": 10.01,
-				"longitude": 10.01,
+			// Attempt creating a user with just the same location.
+			context2 := helpers.CreateTestContext("", `{
+				"latitude": 34.0701449,
+				"longitude": -118.4422936,
 				"address": "1234 Main Street",
 				"taskName": "Task 2",
-				"description": "Description 2",
+				"description": "Description",
 				"points": 20
 			}`)
-			challengeController.Create(duplicateContext2)
-			Expect(duplicateContext2.Writer.Status()).To(Equal(http.StatusOK))
+			challengeController.Create(context2)
+			Expect(context2.Writer.Status()).To(Equal(http.StatusOK))
+
+			// Test that the challenge was written to mongo.
+			_ = mgm.Coll(challenge).First(bson.M{}, challenge)
+			Expect(challenge).NotTo(BeNil())
 
 			// Attempt creating a user with just the same task name.
-			duplicateContext3 := helpers.CreateTestContext("", `{
+			context3 := helpers.CreateTestContext("", `{
 				"latitude": 20.02,
 				"longitude": 20.02,
-				"address": "9999 Oak Street",
+				"address": "1234 Main Street",
 				"taskName": "Task 1",
-				"description": "Description 2",
+				"description": "Description",
 				"points": 20
 			}`)
-			challengeController.Create(duplicateContext3)
-			Expect(duplicateContext3.Writer.Status()).To(Equal(http.StatusOK))
+			challengeController.Create(context3)
+			Expect(context3.Writer.Status()).To(Equal(http.StatusOK))
+
+			// Test that the challenge was written to mongo.
+			_ = mgm.Coll(challenge).First(bson.M{}, challenge)
+			Expect(challenge).NotTo(BeNil())
+
+			// Attempt creating a challenge with the same location & taskName.
+			context4 := helpers.CreateTestContext("", `{
+				"latitude": 34.0701449,
+				"longitude": -118.4422936,
+				"address": "1234 Main Street",
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": 20
+			}`)
+			challengeController.Create(context4)
+			Expect(context4.Writer.Status()).To(Equal(http.StatusBadRequest))
+
+			// Attempt creating challenge with no location/address info, but same task name
+			context5 := helpers.CreateTestContext("", `{
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": 20
+			}`)
+			challengeController.Create(context5)
+			Expect(context5.Writer.Status()).To(Equal(http.StatusBadRequest))
 
 		}))
+
+		It("Test No Location Info", helpers.TestWithMongo("ChallengeController-Create-No-Location", func() {
+
+			// Attempt creating a challenge with only the minimum required fields.
+			context := helpers.CreateTestContext("", `{
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": 20
+			}`)
+			challengeController.Create(context)
+			Expect(context.Writer.Status()).To(Equal(http.StatusOK))
+
+			// Test that the challenge was written to mongo.
+			challenge := &models.Challenge{}
+			_ = mgm.Coll(challenge).First(bson.M{}, challenge)
+			Expect(challenge).NotTo(BeNil())
+
+			// Attempt creating a challenge with the same taskName.
+			duplicateContext := helpers.CreateTestContext("", `{
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": 20
+			}`)
+			challengeController.Create(duplicateContext)
+			Expect(duplicateContext.Writer.Status()).To(Equal(http.StatusBadRequest))
+
+		}))
+
+		It("Test Invalid Arguments", helpers.TestWithMongo("ChallengeController-Create-Invalid-Args", func() {
+
+			// Create a sample request for a challenge to be created, with an invalid (negative) point value.
+			context := helpers.CreateTestContext("", `{
+				"latitude": 10.01,
+				"longitude": 10.01,
+				"address": "1234 Main Street",
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": -1
+			}`)
+
+			// Test the challenge, and that the response is bad.
+			challengeController.Create(context)
+			Expect(context.Writer.Status()).To(Equal(http.StatusBadRequest))
+
+			// Create a sample request for a challenge to be created, with an invalid (decimal) point value.
+			context2 := helpers.CreateTestContext("", `{
+				"latitude": 10.01,
+				"longitude": 10.01,
+				"address": "1234 Main Street",
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": 10.5
+			}`)
+
+			// Test the challenge, and that the response is bad.
+			challengeController.Create(context2)
+			Expect(context2.Writer.Status()).To(Equal(http.StatusBadRequest))
+
+			// Attempt creating a challenge with invalid lat/long coordinates (out of bounds).
+			context3 := helpers.CreateTestContext("", `{
+				"latitude": 500,
+				"longitude": -500,
+				"address": "1234 Main Street",
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": 20
+			}`)
+
+			// Test the challenge, and that the response is bad.
+			challengeController.Create(context3)
+			Expect(context3.Writer.Status()).To(Equal(http.StatusBadRequest))
+
+		}))
+
+		It("Autopopulates Arguments", helpers.TestWithMongo("ChallengeController-Create-Autopopulate", func() {
+
+			// Create a sample request for a challenge to be created, without lat/long.
+			context := helpers.CreateTestContext("", `{
+				"address": "10740 Dickson Ct, Los Angeles, CA 90095",
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": 10
+			}`)
+
+			// Test the first challenge, and that the response is OK.
+			challengeController.Create(context)
+			Expect(context.Writer.Status()).To(Equal(http.StatusOK))
+
+			// Test that the challenge was written to mongo.
+			challenge := &models.Challenge{}
+			_ = mgm.Coll(challenge).First(bson.M{}, challenge)
+			Expect(challenge).NotTo(BeNil())
+
+			// Test that lat/long have been created.
+			Expect(challenge.Location).NotTo(BeNil())
+
+			// Attempt to create a challenge with no lat/long but same address.
+			// Should autopopulate same coordinates & fail.
+			context2 := helpers.CreateTestContext("", `{
+				"address": "10740 Dickson Ct, Los Angeles, CA 90095",
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": 20
+			}`)
+			challengeController.Create(context2)
+			Expect(context2.Writer.Status()).To(Equal(http.StatusBadRequest))
+
+		}))
+
 	})
+
 })

--- a/controllers/challenge_controller_test.go
+++ b/controllers/challenge_controller_test.go
@@ -1,0 +1,83 @@
+package controllers_test
+
+import (
+	"github.com/kamva/mgm/v3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"net/http"
+
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/drift-org/backend/controllers"
+	"github.com/drift-org/backend/helpers"
+	"github.com/drift-org/backend/models"
+)
+
+var _ = Describe("ChallengeController", func() {
+
+	var (
+		challengeController controllers.ChallengeController = controllers.NewChallengeController()
+	)
+
+	Describe("Register", func() {
+		It("Basic", helpers.TestWithMongo("ChallengeController-Create", func() {
+
+			// Create a sample request for a challenge to be created.
+			context := helpers.CreateTestContext("", `{
+				"latitude": 10.01,
+				"longitude": 10.01,
+				"address": "1234 Main Street",
+				"taskName": "Task 1",
+				"description": "Description 1",
+				"points": 10
+			}`)
+
+			// Test the first challenge, and that the response is OK.
+			challengeController.Create(context)
+			Expect(context.Writer.Status()).To(Equal(http.StatusOK))
+
+			// Test that the challenge was written to mongo.
+			challenge := &models.Challenge{}
+			_ = mgm.Coll(challenge).First(bson.M{}, challenge)
+			Expect(challenge).NotTo(BeNil())
+
+			// Attempt creating a challenge with the same address & taskName.
+			duplicateContext1 := helpers.CreateTestContext("", `{
+				"latitude": 10.01,
+				"longitude": 10.01,
+				"address": "1234 Main Street",
+				"taskName": "Task 1",
+				"description": "Description 2",
+				"points": 20
+			}`)
+			challengeController.Create(duplicateContext1)
+			Expect(duplicateContext1.Writer.Status()).To(Equal(http.StatusBadRequest))
+
+			// Attempt creating a user with just the same address.
+			duplicateContext2 := helpers.CreateTestContext("", `{
+				"latitude": 10.01,
+				"longitude": 10.01,
+				"address": "1234 Main Street",
+				"taskName": "Task 2",
+				"description": "Description 2",
+				"points": 20
+			}`)
+			challengeController.Create(duplicateContext2)
+			Expect(duplicateContext2.Writer.Status()).To(Equal(http.StatusOK))
+
+			// Attempt creating a user with just the same task name.
+			duplicateContext3 := helpers.CreateTestContext("", `{
+				"latitude": 20.02,
+				"longitude": 20.02,
+				"address": "9999 Oak Street",
+				"taskName": "Task 1",
+				"description": "Description 2",
+				"points": 20
+			}`)
+			challengeController.Create(duplicateContext3)
+			Expect(duplicateContext3.Writer.Status()).To(Equal(http.StatusOK))
+
+		}))
+	})
+})

--- a/controllers/challenge_controller_test.go
+++ b/controllers/challenge_controller_test.go
@@ -168,6 +168,19 @@ var _ = Describe("ChallengeController", func() {
 			challengeController.Create(context3)
 			Expect(context3.Writer.Status()).To(Equal(http.StatusBadRequest))
 
+			// Create a sample request for a challenge to be created, with invalid lat/long values.
+			context4 := helpers.CreateTestContext("", `{
+				"latitude": 1000,
+				"longitude": -1000,
+				"address": "1234 Main Street",
+				"taskName": "Task 1",
+				"description": "Description",
+				"points": 10.5
+			}`)
+
+			// Test the challenge, and that the response is bad.
+			challengeController.Create(context4)
+			Expect(context4.Writer.Status()).To(Equal(http.StatusBadRequest))
 		}))
 
 		It("Autopopulates Arguments", helpers.TestWithMongo("ChallengeController-Create-Autopopulate", func() {

--- a/helpers/challenge_helpers.go
+++ b/helpers/challenge_helpers.go
@@ -6,6 +6,9 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+// Default lat/long are given as UCLA's coordinates. Default radius is arbitrarily set to 10.
+const DEFAULT_LATITUDE, DEFAULT_LONGITUDE, DEFAULT_RADIUS = 34.0701449, -118.4422936, 10
+
 func milesToMeter(miles uint8) float64 {
 	const METERS_PER_MILE = 1609.344
 	return float64(miles) * METERS_PER_MILE
@@ -44,4 +47,30 @@ func FindChallenge(longitude float64, latitude float64, radius uint8) (*[]models
 		return nil, err
 	}
 	return &results, nil
+}
+
+/*
+TODO: This helper function geocodes the provided address to a valid set
+of lat/long coordinates. Currently, it returns a default response of coordinates,
+currently UCLA's location.
+
+Parameters:
+- address is the address, in string format, provided by the user
+*/
+func GeocodeAddress(address string) (float64, float64, error) {
+	// Return the default lat/long coordinates for now.
+	return DEFAULT_LATITUDE, DEFAULT_LONGITUDE, nil
+}
+
+/*
+Helper function to determine if lat and long coordinates are valid.
+
+Parameters:
+- latitude is the latitude of the given location
+- longitude is the longitude of the given location
+*/
+func ValidateCoordinates(latitude float64, longitude float64) bool {
+	// TODO: Possibly add an optional "address" field where we verify that the coordinates & the address point
+	// to the same location?
+	return (-90 <= latitude && latitude <= 90) && (-180 <= longitude && longitude <= 180)
 }

--- a/models/challenge_model.go
+++ b/models/challenge_model.go
@@ -16,11 +16,11 @@ type Location struct {
 
 type Challenge struct {
 	mgm.DefaultModel `bson:",inline"`
-	Location         Location `bson:"location" json:"location"`
-	Address          string   `bson:"address" json:"address"`
-	TaskName         string   `bson:"taskName" json:"taskName" binding:"required"`
-	Description      string   `bson:"description" json:"description" binding:"required"`
-	Points           int      `bson:"points" json:"points" binding:"required"`
+	Location         *Location `bson:"location,omitempty" json:"location,omitempty"`
+	Address          string    `bson:"address" json:"address"`
+	TaskName         string    `bson:"taskName" json:"taskName" binding:"required"`
+	Description      string    `bson:"description" json:"description" binding:"required"`
+	Points           int       `bson:"points" json:"points" binding:"required"`
 }
 
 func (model *Challenge) Saving() error {
@@ -28,7 +28,7 @@ func (model *Challenge) Saving() error {
 		return err
 	}
 
-	if model.Location.Coordinates != nil {
+	if model.Location != nil {
 		// Set the location type to "Point" for when the coordinates
 		// field of challenges are modified (could be during create or update).
 		model.Location.Type = "Point"

--- a/models/challenge_model.go
+++ b/models/challenge_model.go
@@ -24,12 +24,12 @@ type Location struct {
 //        object with Location & Address.
 // Case 4: Location (not provided), Address (not provided)
 //      - Create object as usual, without both information.
-//        Validate duplicates based only on taskName.
+//        Validate duplicates based only on name.
 type Challenge struct {
 	mgm.DefaultModel `bson:",inline"`
 	Location         *Location `bson:"location,omitempty" json:"location,omitempty"`
 	Address          string    `bson:"address" json:"address"`
-	TaskName         string    `bson:"taskName" json:"taskName" binding:"required"`
+	Name             string    `bson:"name" json:"name" binding:"required"`
 	Description      string    `bson:"description" json:"description" binding:"required"`
 	Points           int       `bson:"points" json:"points" binding:"required,min=0"`
 }

--- a/models/challenge_model.go
+++ b/models/challenge_model.go
@@ -14,13 +14,24 @@ type Location struct {
 	Coordinates []float64 `json:"coordinates" bson:"coordinates" binding:"required"`
 }
 
+// Location (lat/long) and Address information are optional.
+// Case 1: Location (provided), Address (provided)
+//      - Create object as usual.
+// Case 2: Location (provided), Address (not provided)
+//      - Create object with Location, but no Address.
+// Case 3: Location (not provided), Address (provided)
+//      - Geocode address and retrieve lat/long, create
+//        object with Location & Address.
+// Case 4: Location (not provided), Address (not provided)
+//      - Create object as usual, without both information.
+//        Validate duplicates based only on taskName.
 type Challenge struct {
 	mgm.DefaultModel `bson:",inline"`
 	Location         *Location `bson:"location,omitempty" json:"location,omitempty"`
 	Address          string    `bson:"address" json:"address"`
 	TaskName         string    `bson:"taskName" json:"taskName" binding:"required"`
 	Description      string    `bson:"description" json:"description" binding:"required"`
-	Points           int       `bson:"points" json:"points" binding:"required"`
+	Points           int       `bson:"points" json:"points" binding:"required,min=0"`
 }
 
 func (model *Challenge) Saving() error {

--- a/routes/challenge_route.go
+++ b/routes/challenge_route.go
@@ -15,7 +15,5 @@ func challengeRoute(g *gin.RouterGroup) {
 	   In the future, when account roles are added and ADMIN status
 	   can be validated, additional auth middleware will be inserted in.
 	*/
-	// g.POST("/", middleware.VerifyAuthenticated(), challengeController.Create)
-
 	g.POST("/", challengeController.Create)
 }

--- a/routes/challenge_route.go
+++ b/routes/challenge_route.go
@@ -1,0 +1,21 @@
+package routes
+
+import (
+	"github.com/drift-org/backend/controllers"
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	challengeController controllers.ChallengeController = controllers.NewChallengeController()
+)
+
+func challengeRoute(g *gin.RouterGroup) {
+
+	/*
+	   In the future, when account roles are added and ADMIN status
+	   can be validated, additional auth middleware will be inserted in.
+	*/
+	// g.POST("/", middleware.VerifyAuthenticated(), challengeController.Create)
+
+	g.POST("/", challengeController.Create)
+}

--- a/routes/server.go
+++ b/routes/server.go
@@ -19,6 +19,7 @@ func SetupRouter() {
 	authRoute(router.Group("/auth"))
 	groupRoute(router.Group("/group"))
 	prizeRoute(router.Group("/prize"))
+	challengeRoute(router.Group("/challenge"))
 
 	router.Run()
 }


### PR DESCRIPTION
# Contributors
@anjanbharadwaj

# Relevant issue
Closes #26 

# Summary of change
- Route for admins to create challenges
- Some utility functions for validating coordinates
- Set up geocoding util function (TODO)
- Tests

# Testing/Verification
Tested via Postman & Ginkgo

Sample cURL:

```
curl --location --request POST 'localhost:8080/challenge' \
-H 'Content-Type: application/json' \
--data-raw '{
    "address": "123 Main Street",
    "latitude": 10.3,
    "longitude": 10.79,
    "taskName": "hi",
    "description": "description",
    "points": 10
}'
```